### PR TITLE
Remove passing in unneeded data

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -35,10 +35,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         _.each(result.data.allMarkdownRemark.edges, edge => {
           createPage({
             path: edge.node.frontmatter.path,
-            component: blogPost,
-            context: {
-              path: edge.node.frontmatter.path,
-            },
+            component: blogPost
           })
         })
       })


### PR DESCRIPTION
`path` is already accessible in graphql queries so doesn't need pass in via "context".

Fixes validation error https://github.com/gatsbyjs/gatsby/pull/4242#event-1490995206