### PR TITLE
fix UX bug in contact form message textarea

### DIFF
--- a/src/assets/scss/components/_form.scss
+++ b/src/assets/scss/components/_form.scss
@@ -88,6 +88,7 @@
 		padding: 0 1em;
 		text-decoration: none;
 		width: 100%;
+		resize: vertical;
 
 		&:invalid {
 			box-shadow: none;


### PR DESCRIPTION
The message textarea on the contact form becomes unresizable once it has been horizontally resized larger than its container.

Most use cases don't need a horizontally-resizable textarea anyway.
This fix adds a line on _form.scss and affects any other textarea inside the project.
